### PR TITLE
Added support for dashed css property format in get and set

### DIFF
--- a/jss.js
+++ b/jss.js
@@ -140,6 +140,9 @@ var jss = (function (undefined) {
         }
     };
     
+    jss._toCamelCase = function(prop) {
+		return prop.replace(/-([a-z])/gi, function(s, group1) {return group1.toUpperCase();});
+	};
     
     // Object structure for some code candy
     Jss = function () {};
@@ -162,7 +165,7 @@ var jss = (function (undefined) {
             }
 
             this.selector = selector;
-
+			
             return this;
         },
         add: function (prop, value) {
@@ -181,7 +184,8 @@ var jss = (function (undefined) {
         },
         set: function (prop, value) {
             var i,
-                rules;
+                rules,
+				propName;
 
             if (value === undefined) {
                 if (prop && typeof prop == 'object') {
@@ -192,9 +196,10 @@ var jss = (function (undefined) {
                 }
             } else {
                 rules = jss._getRules(this.sheets, this.selector);
+				propName = jss._toCamelCase(prop);
                 // Set properties for each rule
                 for (i = 0; i < rules.length; i++) {
-                    rules[i].style[prop] = value;
+                    rules[i].style[propName] = value;
                 }
             }
 
@@ -208,9 +213,11 @@ var jss = (function (undefined) {
                 j;
 
             if (prop !== undefined) {
+				propName = jss._toCamelCase(prop);
                 for (i = rules.length - 1; i >=0; i--) {
-                    if (rules[i].style[prop] != null) {
-                        result = rules[i].style[prop];
+					// added test for emtpy string to handle style selector defined more than once
+                    if (rules[i].style[propName] != null && rules[i].style[propName] != '') {
+                        result = rules[i].style[propName];
                         break;
                     }
                 }
@@ -218,12 +225,12 @@ var jss = (function (undefined) {
                 result = {};
                 for (i = 0; i < rules.length; i++) {
                     for (j = 0; j < rules[i].style.length; j++) {
-                        propName = rules[i].style[j];
-                        result[propName] = rules[i].style[propName];
+						propName = rules[i].style[j];
+						result[propName] = rules[i].style[propName];
                     }
                 }
             }
-
+			
             return result;
         },
         remove: function () {


### PR DESCRIPTION
Added a method to convert a css property from dashed format (background-color) to camel case format (backgroundColor), so now it supports both. Makes things slightly more convenient to use, though perhaps at a slight performance cost, so there are pro's and con's with this.
