### PR TITLE
Adjselattrswap

### DIFF
--- a/jss.js
+++ b/jss.js
@@ -120,7 +120,8 @@ var jss = (function (undefined) {
         return results;
     };
 	
-	// IE9 stores rules with attributes (classes or ID's) adjacent in the opposite order as defined, causing them to not be found, so this method swaps [#|.]sel1[#|.]sel2 to become [#|.]sel2[#|.]sel1
+	// IE9 stores rules with attributes (classes or ID's) adjacent in the opposite order as defined
+	// causing them to not be found, so this method swaps [#|.]sel1[#|.]sel2 to become [#|.]sel2[#|.]sel1
 	jss._swapAdjSelAttr = function (selector) {
 		var swap = '',
 			lastIndex = 0;


### PR DESCRIPTION
This is an updated version of my adjacent selector attribute swap fix. To recap, IE9 stores selector attributes adjacent to each other in opposite order, resulting in no match previously. I've added a method which swaps these, and then tests for that also, which fixed this issue in IE9. Unlike my previous closed pull request, this now supports id attributes as well as class attributes.

As an example, with a css selector like this:
# id1.clsA .clsB.clsC

IE9 stores this as:

.clsA#id1 .clsC.clsB

This pull request adds a method to perform the swap, and test for that also when seeking to match the rule.
