### PR TITLE
fixed issue where if rules are null, they cannot be iterated through

### DIFF
--- a/jss.js
+++ b/jss.js
@@ -98,7 +98,7 @@ var jss = (function (undefined) {
             }
         } else {
             // Single sheet
-            rules = sheet.cssRules || sheet.rules;
+            rules = sheet.cssRules || sheet.rules || [];
             for (i = 0; i < rules.length; i++) {
                 // Warning, selectorText may not be correct in IE<9
                 // as it splits selectors with ',' into multiple rules.


### PR DESCRIPTION
I don't know how common this can be, but I came across the issue with a chrome plugin that changes dom.
